### PR TITLE
Pull to main branch

### DIFF
--- a/KH-2002/config.cpp
+++ b/KH-2002/config.cpp
@@ -1,0 +1,544 @@
+class cfgPatches
+{
+  class RSF_KH2002_Conversion
+  {
+    name = "RSF KH-2002 Conversion Mod";
+    author = "Nero / SpartanD39";
+    url = "";
+    version="0.0.1";
+    versionStr="0.0.1";
+    requiredAddons[] =
+    {
+      "A3_Weapons_F",
+      "A3_Weapons_F_Mark",
+      "A3_Sounds_F",
+      "ace_advanced_ballistics",
+      "ace_advanced_fatigue",
+      "ace_advanced_throwing",
+  		"ace_ai",
+      "ace_aircraft",
+      "ace_apl",
+      "ace_arsenal",
+      "ace_atragmx",
+      "ace_attach",
+      "ace_backpacks",
+      "ace_ballistics",
+      "ace_captives",
+      "ace_cargo",
+      "ace_chemlights",
+      "ace_common",
+      "ace_concertina_wire",
+      "ace_cookoff",
+      "ace_dagr",
+      "ace_disarming",
+      "ace_disposable",
+      "ace_dogtags",
+      "ace_dragging",
+      "ace_explosives",
+      "ace_fastroping",
+      "ace_fcs",
+      "ace_finger",
+      "ace_flashlights",
+      "ace_flashsuppressors",
+      "ace_fonts",
+      "ace_frag",
+      "ace_gestures",
+      "ace_gforces",
+      "ace_goggles",
+      "ace_grenades",
+      "ace_gunbag",
+      "ace_hearing",
+      "ace_hellfire",
+      "ace_hitreactions",
+      "ace_hot",
+      "ace_huntir",
+      "ace_interact_menu",
+      "ace_interaction",
+      "ace_inventory",
+      "ace_javelin",
+      "ace_kestrel4500",
+      "ace_laser",
+      "ace_laserpointer",
+      "ace_logistics_uavbattery",
+      "ace_logistics_wirecutter",
+      "ace_magazinerepack",
+      "ace_main",
+      "ace_map",
+      "ace_map_gestures",
+      "ace_maptools",
+      "ace_markers",
+      "ace_maverick",
+      "ace_medical",
+      "ace_medical_ai",
+      "ace_medical_blood",
+      "ace_medical_menu",
+      "ace_microdagr",
+      "ace_minedetector",
+      "ace_missileguidance",
+      "ace_missionmodules",
+      "ace_mk6mortar",
+      "ace_modules",
+      "ace_movement",
+      "ace_mx2a",
+      "ace_nametags",
+      "ace_nightvision",
+      "ace_nlaw",
+      "ace_noidle",
+      "ace_noradio",
+      "ace_norearm",
+      "ace_optics",
+      "ace_optionsmenu",
+      "ace_overheating",
+      "ace_overpressure",
+      "ace_parachute",
+      "ace_pylons",
+      "ace_quickmount",
+      "ace_rangecard",
+      "ace_realisticnames",
+      "ace_realisticweights",
+      "ace_rearm",
+      "ace_recoil",
+      "ace_refuel",
+      "ace_reload",
+      "ace_reloadlaunchers",
+      "ace_repair",
+      "ace_respawn",
+      "ace_safemode",
+      "ace_sandbag",
+      "ace_scopes",
+      "ace_slideshow",
+      "ace_smallarms",
+      "ace_spectator",
+      "ace_spottingscope",
+      "ace_switchunits",
+      "ace_tacticalladder",
+      "ace_tagging",
+      "ace_thermals",
+      "ace_trenches",
+      "ace_tripod",
+      "ace_ui",
+      "ace_vector",
+      "ace_vehiclelock",
+      "ace_vehicles",
+      "ace_viewdistance",
+      "ace_weaponselect",
+      "ace_weather",
+      "ace_winddeflection",
+  		"ace_yardage450",
+      "ace_zeus"
+		};
+
+    units[] = {};
+    weapons[] = {};
+
+  };
+
+};
+
+class CfgMagazineWells
+{
+	class nth_556x45_katiba
+	{
+		KH_Magazines[] =
+		{
+		"ACE_30Rnd_556x45_Stanag_M995_AP_mag",
+  		"ACE_30Rnd_556x45_Stanag_Mk262_mag",
+  		"ACE_30Rnd_556x45_Stanag_Mk318_mag",
+  		"ACE_30Rnd_556x45_Stanag_Tracer_Dim",
+  		"30Rnd_556x45_Stanag",
+  		"30Rnd_556x45_Stanag_green",
+  		"30Rnd_556x45_Stanag_red",
+  		"30Rnd_556x45_Stanag_Tracer_Red",
+  		"30Rnd_556x45_Stanag_Tracer_Green",
+  		"30Rnd_556x45_Stanag_Tracer_Yellow",
+  		"rhs_mag_30Rnd_556x45_M855_Stanag",
+  		"rhs_mag_30Rnd_556x45_M855_Stanag_Tracer_Red",
+  		"rhs_mag_30Rnd_556x45_M855_Stanag_Tracer_Green",
+  		"rhs_mag_30Rnd_556x45_M855_Stanag_Tracer_Yellow",
+  		"rhs_mag_30Rnd_556x45_M855_Stanag_Tracer_Orange",
+  		"rhs_mag_30Rnd_556x45_M855A1_Stanag",
+  		"rhs_mag_30Rnd_556x45_M855A1_Stanag_No_Tracer",
+  		"rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red",
+  		"rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Green",
+  		"rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Yellow",
+  		"rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Orange",
+  		"rhs_mag_30Rnd_556x45_Mk318_Stanag",
+  		"rhs_mag_30Rnd_556x45_Mk262_Stanag",
+  		"rhs_mag_30Rnd_556x45_M200_Stanag",
+  		"rhs_mag_30Rnd_556x45_M855A1_PMAG",
+  		"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tracer_Red",
+  		"rhs_mag_30Rnd_556x45_M855_PMAG",
+  		"rhs_mag_30Rnd_556x45_M855_PMAG_Tracer_Red",
+  		"rhs_mag_30Rnd_556x45_Mk318_PMAG",
+  		"rhs_mag_30Rnd_556x45_Mk262_PMAG",
+  		"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tan",
+  		"rhs_mag_30Rnd_556x45_M855A1_PMAG_Tan_Tracer_Red",
+  		"rhs_mag_30Rnd_556x45_M855_PMAG_Tan",
+  		"rhs_mag_30Rnd_556x45_M855_PMAG_Tan_Tracer_Red",
+  		"rhs_mag_30Rnd_556x45_Mk318_PMAG_Tan",
+  		"rhs_mag_30Rnd_556x45_Mk262_PMAG_Tan"
+		};
+	};
+	
+};
+
+class Mode_FullAuto;
+class Mode_Burst;
+class Mode_SemiAuto;
+class WeaponSlotsInfo;
+class MuzzleSlot;
+class SlotInfo;
+class CowsSlot;
+class PointerSlot;
+class BaseSoundModeType;
+
+class CfgWeapons
+{
+  class arifle_Katiba_base_F;
+
+  class arifle_Katiba_F: arifle_Katiba_base_F
+  {
+    displayName="KH-2002";
+		descriptionShort = "Assault Rifle<br />Caliber: 5.56x45 mm";
+		caseless[] = {"",0,0,0};
+		linkProxy="\A3\data_f\proxies\weapon_slots\MAGAZINESLOT";
+		magazines[] ={};
+		magazineWell[] = {"nth_556x45_katiba"};
+
+    modes[]=
+  	{
+  		"Single",
+      "Burst",
+  		"FullAuto",
+  		"single_medium_optics1",
+  		"single_far_optics2",
+  		"fullauto_medium"
+    };
+
+    soundBurst=false;
+	  class Burst: Mode_Burst
+	  {
+  		reloadTime=0.075000003;
+  		dispersion=0.0022;
+  		minRange=1;
+  		minRangeProbab=0.69999999;
+  		midRange=60;
+  		midRangeProbab=0.80000001;
+  		maxRange=120;
+  		maxRangeProbab=0.2;
+
+      sounds[]=
+			{
+				"StandardSound",
+				"SilencedSound"
+			};
+
+      class BaseSoundModeType
+			{
+				closure1[]=
+				{
+					"A3\Sounds_F\arsenal\weapons\Rifles\Katiba\closure_Katiba_01",
+					0.17782794,
+					1,
+					10
+				};
+				closure2[]=
+				{
+					"A3\Sounds_F\arsenal\weapons\Rifles\Katiba\closure_Katiba_02",
+					0.17782794,
+					1,
+					10
+				};
+				soundClosure[]=
+				{
+					"closure1",
+					0.5,
+					"closure2",
+					0.5
+				};
+			};
+
+      class StandardSound: BaseSoundModeType
+			{
+				soundSetShot[]=
+				{
+					"Katiba_Shot_SoundSet",
+					"Katiba_Tail_SoundSet",
+					"Katiba_InteriorTail_SoundSet"
+				};
+				begin1[]=
+				{
+					"A3\Sounds_F\arsenal\weapons\Rifles\Katiba\Katiba_short_01",
+					3.1622777,
+					1,
+					1800
+				};
+				begin2[]=
+				{
+					"A3\Sounds_F\arsenal\weapons\Rifles\Katiba\Katiba_short_02",
+					3.1622777,
+					1,
+					1800
+				};
+				begin3[]=
+				{
+					"A3\Sounds_F\arsenal\weapons\Rifles\Katiba\Katiba_short_03",
+					3.1622777,
+					1,
+					1800
+				};
+				soundBegin[]=
+				{
+					"begin1",
+					0.33000001,
+					"begin2",
+					0.33000001,
+					"begin2",
+					0.34
+				};
+				class SoundTails
+				{
+					class TailInterior
+					{
+						sound[]=
+						{
+							"A3\Sounds_F\arsenal\weapons\Rifles\Katiba\Katiba_tail_interior",
+							2.2387211,
+							1,
+							1800
+						};
+						frequency=1;
+						volume="interior";
+					};
+					class TailTrees
+					{
+						sound[]=
+						{
+							"A3\Sounds_F\arsenal\weapons\Rifles\Katiba\Katiba_tail_trees",
+							1,
+							1,
+							1800
+						};
+						frequency=1;
+						volume="(1-interior/1.4)*trees";
+					};
+					class TailForest
+					{
+						sound[]=
+						{
+							"A3\Sounds_F\arsenal\weapons\Rifles\Katiba\Katiba_tail_forest",
+							1,
+							1,
+							1800
+						};
+						frequency=1;
+						volume="(1-interior/1.4)*forest";
+					};
+					class TailMeadows
+					{
+						sound[]=
+						{
+							"A3\Sounds_F\arsenal\weapons\Rifles\Katiba\Katiba_tail_meadows",
+							1,
+							1,
+							1800
+						};
+						frequency=1;
+						volume="(1-interior/1.4)*(meadows/2 max sea/2)";
+					};
+					class TailHouses
+					{
+						sound[]=
+						{
+							"A3\Sounds_F\arsenal\weapons\Rifles\Katiba\Katiba_tail_houses",
+							1,
+							1,
+							1800
+						};
+						frequency=1;
+						volume="(1-interior/1.4)*houses";
+					};
+				};
+			};
+
+      class SilencedSound: BaseSoundModeType
+			{
+				soundSetShot[]=
+				{
+					"Katiba_silencerShot_SoundSet",
+					"Katiba_silencerTail_SoundSet",
+					"Katiba_silencerInteriorTail_SoundSet"
+				};
+				begin1[]=
+				{
+					"A3\Sounds_F\arsenal\weapons\Rifles\Katiba\Silencer_Katiba_short_01",
+					0.79432821,
+					1,
+					400
+				};
+				begin2[]=
+				{
+					"A3\Sounds_F\arsenal\weapons\Rifles\Katiba\Silencer_Katiba_short_02",
+					0.79432821,
+					1,
+					400
+				};
+				begin3[]=
+				{
+					"A3\Sounds_F\arsenal\weapons\Rifles\Katiba\Silencer_Katiba_short_03",
+					0.79432821,
+					1,
+					400
+				};
+				soundBegin[]=
+				{
+					"begin1",
+					0.33000001,
+					"begin2",
+					0.33000001,
+					"begin3",
+					0.34
+				};
+				class SoundTails
+				{
+					class TailInterior
+					{
+						sound[]=
+						{
+							"A3\Sounds_F\arsenal\weapons\Rifles\Katiba\Silencer_Katiba_Tail_interior",
+							1,
+							1,
+							400
+						};
+						frequency=1;
+						volume="interior";
+					};
+					class TailTrees
+					{
+						sound[]=
+						{
+							"A3\Sounds_F\arsenal\weapons\Rifles\Katiba\Silencer_Katiba_Tail_trees",
+							1,
+							1,
+							400
+						};
+						frequency=1;
+						volume="(1-interior/1.4)*trees";
+					};
+					class TailForest
+					{
+						sound[]=
+						{
+							"A3\Sounds_F\arsenal\weapons\Rifles\Katiba\Silencer_Katiba_Tail_forest",
+							1,
+							1,
+							400
+						};
+						frequency=1;
+						volume="(1-interior/1.4)*forest";
+					};
+					class TailMeadows
+					{
+						sound[]=
+						{
+							"A3\Sounds_F\arsenal\weapons\Rifles\Katiba\Silencer_Katiba_Tail_meadows",
+							1,
+							1,
+							400
+						};
+						frequency=1;
+						volume="(1-interior/1.4)*(meadows/2 max sea/2)";
+					};
+					class TailHouses
+					{
+						sound[]=
+						{
+							"A3\Sounds_F\arsenal\weapons\Rifles\Katiba\Silencer_Katiba_Tail_houses",
+							1,
+							1,
+							400
+						};
+						frequency=1;
+						volume="(1-interior/1.4)*houses";
+					};
+				};
+			};
+
+	  };
+
+	class WeaponSlotsInfo: WeaponSlotsInfo
+	{
+		class MuzzleSlot: MuzzleSlot
+		{
+			linkProxy="\A3\data_f\proxies\weapon_slots\MUZZLE";
+			compatibleItems[]=
+			{
+			"ace_muzzle_mzls_l",
+			"ffaa_snds_gt_556",
+			"rhsusf_acc_nt4_black",
+			"rhsusf_acc_nt4_tan",
+			"rhsusf_acc_rotex5_grey",
+			"rhsusf_acc_rotex5_tan",
+			"muzzle_snds_m_snd_f",
+			"muzzle_snds_m_khk_f",
+			"muzzle_snds_m"
+			};
+		};
+	};
+
+};
+
+class arifle_Katiba_C_F: arifle_Katiba_F
+	{
+    displayName="KH-2002C";
+	
+		class WeaponSlotsInfo: WeaponSlotsInfo
+		{
+			class MuzzleSlot: MuzzleSlot
+			{
+				linkProxy="\A3\data_f\proxies\weapon_slots\MUZZLE";
+				compatibleItems[]= 
+				{
+				"ace_muzzle_mzls_l",
+				"ffaa_snds_gt_556",
+				"rhsusf_acc_nt4_black",
+				"rhsusf_acc_nt4_tan",
+				"rhsusf_acc_rotex5_grey",
+				"rhsusf_acc_rotex5_tan",
+				"muzzle_snds_m_snd_f",
+				"muzzle_snds_m_khk_f",
+				"muzzle_snds_m"
+				};
+			};		
+	
+		};
+	};
+
+	class arifle_Katiba_GL_F: arifle_Katiba_F
+	{
+		displayName="KH-2002 UGL";
+		
+		class WeaponSlotsInfo: WeaponSlotsInfo
+		{
+			class MuzzleSlot: MuzzleSlot
+			{
+				linkProxy="\A3\data_f\proxies\weapon_slots\MUZZLE";
+				compatibleItems[]= 
+				{
+				"ace_muzzle_mzls_l",
+				"ffaa_snds_gt_556",
+				"rhsusf_acc_nt4_black",
+				"rhsusf_acc_nt4_tan",
+				"rhsusf_acc_rotex5_grey",
+				"rhsusf_acc_rotex5_tan",
+				"muzzle_snds_m_snd_f",
+				"muzzle_snds_m_khk_f",
+				"muzzle_snds_m"
+				};
+				
+			};		
+	
+		};
+	};
+
+};

--- a/MG5/config.cpp
+++ b/MG5/config.cpp
@@ -1,0 +1,105 @@
+class cfgPatches 
+{
+    class RSF_MG5_Conversion 
+    {
+        name = "RSF MG5 Conversion Mod";
+        author = "Nero";
+        url = "";
+        version="0.0.1";
+        versionStr="0.0.1";
+        requiredAddons[] = {"A3_Weapons_F","ace_advanced_ballistics","ace_advanced_fatigue","ace_advanced_throwing",
+		"ace_ai","ace_aircraft","ace_apl","ace_arsenal","ace_atragmx","ace_attach","ace_backpacks","ace_ballistics",
+		"ace_captives","ace_cargo","ace_chemlights","ace_common","ace_concertina_wire","ace_cookoff","ace_dagr",
+		"ace_disarming","ace_disposable","ace_dogtags","ace_dragging","ace_explosives","ace_fastroping","ace_fcs",
+		"ace_finger","ace_flashlights","ace_flashsuppressors","ace_fonts","ace_frag","ace_gestures","ace_gforces",
+		"ace_goggles","ace_grenades","ace_gunbag","ace_hearing","ace_hellfire","ace_hitreactions","ace_hot",
+		"ace_huntir","ace_interact_menu","ace_interaction","ace_inventory","ace_javelin","ace_kestrel4500",
+		"ace_laser","ace_laserpointer","ace_logistics_uavbattery","ace_logistics_wirecutter","ace_magazinerepack",
+		"ace_main","ace_map","ace_map_gestures","ace_maptools","ace_markers","ace_maverick","ace_medical","ace_medical_ai",
+		"ace_medical_blood","ace_medical_menu","ace_microdagr","ace_minedetector","ace_missileguidance","ace_missionmodules",
+		"ace_mk6mortar","ace_modules","ace_movement","ace_mx2a","ace_nametags","ace_nightvision","ace_nlaw","ace_noidle",
+		"ace_noradio","ace_norearm","ace_optics","ace_optionsmenu","ace_overheating","ace_overpressure","ace_parachute",
+		"ace_pylons","ace_quickmount","ace_rangecard","ace_realisticnames","ace_realisticweights","ace_rearm",
+		"ace_recoil","ace_refuel","ace_reload","ace_reloadlaunchers","ace_repair","ace_respawn","ace_safemode",
+		"ace_sandbag","ace_scopes","ace_slideshow","ace_smallarms","ace_spectator","ace_spottingscope","ace_switchunits",
+		"ace_tacticalladder","ace_tagging","ace_thermals","ace_trenches","ace_tripod","ace_ui","ace_vector",
+		"ace_vehiclelock","ace_vehicles","ace_viewdistance","ace_weaponselect","ace_weather","ace_winddeflection",
+		"ace_yardage450","ace_zeus"
+		};
+        units[] = {};
+        weapons[] = {};
+    };
+};
+
+class WeaponSlotsInfo;
+class MuzzleSlot;
+class SlotInfo;
+class CowsSlot;
+class PointerSlot;
+
+class CfgWeapons 
+{
+	
+class MMG_01_base_F;	
+
+	 class MMG_01_hex_F: MMG_01_base_F
+    {
+        displayName="MG5 (Hex)";
+		descriptionShort = "Medium Machine Gun<br />Caliber: 7.62x51 mm";
+		magazines[] = 
+		{
+		"120Rnd_762x51_Mag_M61_F",
+		"120Rnd_762x51_Mag_M62_F",
+		"120Rnd_762x51_Mag_M80_F",
+		"120Rnd_762x51_Mag_M80A1_F",
+		"120Rnd_762x51_Mag_M993_AP_F",
+		"120Rnd_762x51_Mag_M82_F",
+		};
+        magazineWell[] = {};
+		
+		class WeaponSlotsInfo: WeaponSlotsInfo
+		{
+			class MuzzleSlot: MuzzleSlot
+			{
+				linkProxy="\A3\data_f\proxies\weapon_slots\MUZZLE";
+				compatibleItems[]= 
+				{
+				"ace_muzzle_mzls_b",
+				"muzzle_snds_h_mg_blk_f",
+				"muzzle_snds_h_mg",
+				};
+			};
+		};		
+    };
+	
+ class MMG_01_tan_F: MMG_01_hex_F
+    {
+        displayName="MG5 (Tan)";
+		descriptionShort = "Medium Machine Gun<br />Caliber: 7.62x51 mm";
+		magazines[] = 
+		{
+		"120Rnd_762x51_Mag_M61_F",
+		"120Rnd_762x51_Mag_M62_F",
+		"120Rnd_762x51_Mag_M80_F",
+		"120Rnd_762x51_Mag_M80A1_F",
+		"120Rnd_762x51_Mag_M993_AP_F",
+		"120Rnd_762x51_Mag_M82_F",
+		};
+        magazineWell[] = {};
+		
+		class WeaponSlotsInfo: WeaponSlotsInfo
+		{
+			class MuzzleSlot: MuzzleSlot
+			{
+				linkProxy="\A3\data_f\proxies\weapon_slots\MUZZLE";
+				compatibleItems[]= 
+				{
+				"ace_muzzle_mzls_b",
+				"muzzle_snds_h_mg_blk_f",
+				"muzzle_snds_h_mg",
+				};
+			};
+		};		
+    };
+	
+};	

--- a/MSBS-5.56B/config.cpp
+++ b/MSBS-5.56B/config.cpp
@@ -35,8 +35,8 @@ class CfgMagazines
 	{
 		ammo = "B_545x39_Ball_Green_F";
 		author="Bohemia Interactive, modified by SpartanD39";
-		displayName = "5.56mm 30Rnd MSBS";
-		displayNameShort = "5.56mm MSBS";
+		displayName = "5.56 mm 30Rnd Mag";
+		displayNameShort = "5.56mm";
 		descriptionShort = "Caliber: 5.56x45mm NATO<br />Rounds: 30<br />Used in: MSBS";
 		initSpeed=920;
 		lastRoundsTracer=4;
@@ -46,8 +46,8 @@ class CfgMagazines
 	{
 		ammo = "B_556x45_Ball_Tracer_Green";
 		author="Bohemia Interactive, modified by SpartanD39";
-		displayName = "5.56mm 30Rnd MSBS Green Tracer";
-		displayNameShort = "5.56mm MSBS (Green)";
+		displayName = "5.56 mm 30Rnd Tracer (Green) Mag";
+		displayNameShort = "5.56mm Tracer";
 		descriptionShort = "Caliber: 5.56x45mm NATO green tracer<br />Rounds: 30<br />Used in: MSBS";
 		tracersEvery = 1;
 	};
@@ -56,8 +56,8 @@ class CfgMagazines
 	{
 		ammo = "B_556x45_Ball_Tracer_Red";
 		author="Bohemia Interactive, modified by SpartanD39";
-		displayName = "5.56mm 30Rnd MSBS Red Tracer";
-		displayNameShort = "5.56mm MSBS (Red)";
+		displayName = "5.56 mm 30Rnd Tracer (Red) Mag";
+		displayNameShort = "5.56mm Tracer";
 		descriptionShort = "Caliber: 5.56x45mm NATO red tracer<br />Rounds: 30<br />Used in: MSBS";
 		tracersEvery = 1;
 	};
@@ -66,8 +66,8 @@ class CfgMagazines
 	{
 		ammo = "B_556x45_Ball_Tracer_Yellow";
 		author="Bohemia Interactive, modified by SpartanD39";
-		displayName = "5.56mm 30Rnd MSBS Yellow Tracer";
-		displayNameShort = "5.56mm MSBS (Yellow)";
+		displayName = "5.56 mm 30Rnd Tracer (Yellow) Mag";
+		displayNameShort = "5.56mm Tracer";
 		descriptionShort = "Caliber: 5.56x45mm NATO yellow tracer<br />Rounds: 30<br />Used in: MSBS";
 		tracersEvery = 1;
 	};
@@ -76,8 +76,8 @@ class CfgMagazines
 	{
 		ammo = "ACE_556x45_Ball_M995_AP";
 		author="Bohemia Interactive, ACE-Team, hacked together by SpartanD39";
-		displayName = "5.56mm 30Rnd M995 AP";
-		displayNameShort = "5.56mm MSBS AP";
+		displayName = "5.5 6mm 30Rnd M995 AP";
+		displayNameShort = "5.56mm M995";
 		descriptionShort = "Caliber: 5.56x45mm NATO M995 AP<br />Rounds: 30<br />Used in: MSBS";
 		initSpeed = 875;
 		lastRoundsTracer=4;
@@ -87,8 +87,8 @@ class CfgMagazines
 	{
 		ammo = "ACE_556x45_Ball_Mk262";
 		author="Bohemia Interactive, ACE-Team, hacked together by SpartanD39";
-		displayName = "5.56mm 30Rnd MSBS Mk262";
-		displayNameShort = "5.56mm MSBS Mk262";
+		displayName = "5.56 mm 30Rnd Mk262";
+		displayNameShort = "5.56mm Mk262";
 		descriptionShort = "Caliber: 5.56x45mm NATO Mk262 high-accuracy rounds<br />Rounds: 30<br />Used in: MSBS";
 		initSpeed = 832;
 		lastRoundsTracer=4;
@@ -98,8 +98,8 @@ class CfgMagazines
 	{
 		ammo = "ACE_556x45_Ball_Mk318";
 		author="Bohemia Interactive, ACE-Team, hacked together by SpartanD39";
-		displayName = "5.56mm 30Rnd MSBS Mk318 SOST";
-		displayNameShort = "5.56mm MSBS Mk318";
+		displayName = "5.56 mm 30Rnd Mk318 SOST";
+		displayNameShort = "5.56mm Mk318";
 		descriptionShort = "Caliber: 5.56x45mm NATO Mk318 SOST<br />Rounds: 30<br />Used in: MSBS";
 		initSpeed = 923;
 		lastRoundsTracer=4;
@@ -109,8 +109,8 @@ class CfgMagazines
 	{
 		ammo = "ACE_B_556x45_Ball_Tracer_Dim";
 		author="Bohemia Interactive, ACE-Team, hacked together by SpartanD39";
-		displayName = "5.56mm 30Rnd MSBS IR-DIM";
-		displayNameShort = "5.56mm MSBS IR-DIM";
+		displayName = "5.56 mm 30Rnd IR-DIM";
+		displayNameShort = "5.56mm IR-DIM";
 		descriptionShort = "Caliber: 5.56x45mm NATO Tracer IR-DIM<br />Rounds: 30<br />Used in: MSBS";
 		initSpeed = 869;
 		tracersEvery = 1;
@@ -1020,87 +1020,87 @@ class cfgWeapons
 	//Base MSBS
 	class arifle_MSBS65_F: arifle_MSBS65_base_F
 	{
-		displayName="MSBS-5.56";
+		displayName="MSBS-5.56B";
 	};
 
 
 	class arifle_MSBS65_black_F: arifle_MSBS65_base_black_F
 	{
-		displayName="MSBS-5.56 (Black)";
+		displayName="MSBS-5.56B (Black)";
 	};
 
 
 	class arifle_MSBS65_camo_F: arifle_MSBS65_base_camo_F
 	{
-		displayName="MSBS-5.56 (Camo)";
+		displayName="MSBS-5.56B (Camo)";
 	};
 
 
 	class arifle_MSBS65_sand_F: arifle_MSBS65_base_sand_F
 	{
-		displayName="MSBS-5.56 (Sand)";
+		displayName="MSBS-5.56B (Sand)";
 	};
 
 	//MSBS GL
 	class arifle_MSBS65_GL_F: arifle_MSBS65_GL_base_F
 	{
-		displayName="MSBS-5.56GL";
+		displayName="MSBS-5.56B UGL";
 	};
 
 	class arifle_MSBS65_GL_black_F: arifle_MSBS65_GL_base_black_F
 	{
-		displayName="MSBS-5.56GL (Black)";
+		displayName="MSBS-5.56B UGL (Black)";
 	};
 
 	class arifle_MSBS65_GL_camo_F: arifle_MSBS65_GL_base_camo_F
 	{
-		displayName="MSBS-5.56GL (Camo)";
+		displayName="MSBS-5.56B UGL (Camo)";
 	};
 
 	class arifle_MSBS65_GL_sand_F: arifle_MSBS65_GL_base_sand_F
 	{
-		displayName="MSBS-5.56GL (Sand)";
+		displayName="MSBS-5.56B UGL (Sand)";
 	};
 
 	//MSBS Marksman
 	class arifle_MSBS65_Mark_F: arifle_MSBS65_Mark_base_F
 	{
-		displayName="MSBS-762N";
+		displayName="MSBS-7.62N";
 	};
 
 	class arifle_MSBS65_Mark_black_F: arifle_MSBS65_Mark_base_black_F
 	{
-		displayName="MSBS-762N (Black)";
+		displayName="MSBS-7.62N (Black)";
 	};
 
 	class arifle_MSBS65_Mark_camo_F: arifle_MSBS65_Mark_base_camo_F
 	{
-		displayName="MSBS-762N (Camo)";
+		displayName="MSBS-7.62N (Camo)";
 	};
 
 	class arifle_MSBS65_Mark_sand_F: arifle_MSBS65_Mark_base_sand_F
 	{
-		displayName="MSBS-762N (Sand)";
+		displayName="MSBS-7.62N (Sand)";
 	};
 
 	//MSBS Uderbarrel Shotgun
 	class arifle_MSBS65_UBS_F: arifle_MSBS65_UBS_base_F
 	{
-		displayName="MSBS-5.56UBS ";
+		displayName="MSBS-5.56B SIX12";
 	};
 
 	class arifle_MSBS65_UBS_black_F: arifle_MSBS65_UBS_base_black_F
 	{
-		displayName="MSBS-5.56UBS (Black)";
+		displayName="MSBS-5.56B SIX12 (Black)";
 	};
 
 	class arifle_MSBS65_UBS_camo_F: arifle_MSBS65_UBS_base_camo_F
 	{
-		displayName="MSBS-5.56UBS (Camo)";
+		displayName="MSBS-5.56B SIX12 (Camo)";
 	};
 
 	class arifle_MSBS65_UBS_sand_F: arifle_MSBS65_UBS_base_sand_F
 	{
-		displayName="MSBS-5.56UBS (Sand)";
+		displayName="MSBS-5.56B SIX12 (Sand)";
 	};
 };

--- a/Magazines/MG5/config.cpp
+++ b/Magazines/MG5/config.cpp
@@ -1,0 +1,82 @@
+class CfgPatches
+{
+	class mg5_ammoMod
+	{
+		name = "MG5 120Rnd Magazine";
+		author = "Nero";
+		url = "";
+		version="0.0.1";
+		versionStr="0.0.1";
+		requiredAddons[]=
+		{
+			"A3_Weapons_F",
+			"A3_Weapons_F_Mark"
+		};
+		units[] = {};
+		weapons[] = {};
+	};
+};
+
+class CfgMagazines
+{
+  class Default;
+  class CA_Magazine: Default {};
+  
+	class 120Rnd_762x51_Mag_M61_F: CA_Magazine
+	{
+	picture = "\A3\Weapons_F_Mark\Data\UI\M_93x64_CA.paa";
+	scope=2;
+	displayName = "7.62 mm 120Rnd M61 AP Box";
+	displayNameShort = "";
+	descriptionShort = "Caliber: 7.62x51 mm<br />Rounds: 120<br />Used in: MG5";
+	ammo="rhs_ammo_762x51_M61_AP";
+	count = 120;
+	initSpeed=838;
+	tracersEvery=5;
+	lastRoundsTracer=0;
+	mass=38
+	};
+
+  class 120Rnd_762x51_Mag_M62_F: 120Rnd_762x51_Mag_M61_F
+	{
+	displayName = "7.62 mm 120Rnd M62 (Tracer) Box";
+	ammo="rhs_ammo_762x51_M62_Tracer";
+	tracersEvery=1;
+	lastRoundsTracer=0;
+	};
+  
+   class 120Rnd_762x51_Mag_M80_F: 120Rnd_762x51_Mag_M61_F
+	{
+	displayName = "7.62 mm 120Rnd M80 Box";
+	ammo="rhs_ammo_762x51_M80_Ball";
+	};
+  
+   class 120Rnd_762x51_Mag_M80A1_F: 120Rnd_762x51_Mag_M61_F
+	{
+	displayName = "7.62 mm 120Rnd M80A1 EPR Box";
+	ammo="rhs_ammo_762x51_M80A1EPR_Ball";
+	initSpeed=803;
+	};
+  
+    class 120Rnd_762x51_Mag_M993_AP_F: 120Rnd_762x51_Mag_M61_F
+	{
+	displayName = "7.62 mm 120Rnd M993 AP Box";
+	ammo="rhs_ammo_762x51_M993_Ball";
+	initSpeed=911;
+	};
+  
+  	class 120Rnd_762x51_Mag_M82_F: CA_Magazine
+	{
+	picture = "\A3\Weapons_F_Mark\Data\UI\M_93x64_CA.paa";
+	scope=2;
+	displayName = "7.62 mm 120Rnd M82 (Blank) Box";
+	displayNameShort = "";
+	descriptionShort = "Caliber: 7.62x51 mm<br />Rounds: 120<br />Used in: MG5";
+	ammo="rhs_ammo_762x51_M82_blank";
+	count = 120;
+	initSpeed=838;
+	tracersEvery=5;
+	lastRoundsTracer=0;
+	mass=38
+	};
+};

--- a/Magazines/QBU-88/config.cpp
+++ b/Magazines/QBU-88/config.cpp
@@ -1,0 +1,56 @@
+class CfgPatches
+{
+	class qbu_ammoMod
+	{
+		name = "QBU-88 10Rnd Magazine";
+		author = "SpartanD39 / Nero";
+		url = "";
+		version="0.0.1";
+		versionStr="0.0.1";
+		requiredAddons[]=
+		{
+			"A3_Weapons_F",
+			"A3_Weapons_F_Exp"
+		};
+		units[] = {};
+		weapons[] = {};
+	};
+};
+
+class CfgMagazines
+{
+  class Default;
+  class CA_Magazine: Default {};
+  
+	class 10Rnd_580x42_Mag_F: CA_Magazine
+	{
+	picture = "\A3\Weapons_F_Exp\Data\UI\icon_20Rnd_650x39_Cased_Mag_F_ca.paa";
+	scope=2;
+	displayName = "5.8 mm 10Rnd Mag";
+	displayNameShort = "";
+	descriptionShort = "Caliber: 5.8x42 mm<br />Rounds: 10<br />Used in: QBZ-95-1, QBZ-95-1 GL, QBU-88,";
+	ammo="B_580x42_Ball_F";
+	count = 10;
+	initSpeed=950;
+	tracersEvery=0;
+	lastRoundsTracer=0;
+	mass=3
+		hiddenSelections[]=
+		{
+		"Camo"
+		};
+		hiddenSelectionsTextures[]=
+		{
+		"a3\Weapons_F_Exp\Rifles\CTAR\Data\CTAR_F_2_co.paa"
+		};
+	};
+
+  class 10Rnd_580x42_Mag_Tracer_F: 10Rnd_580x42_Mag_F
+  {
+	picture = "\A3\Weapons_F_Exp\Data\UI\icon_20Rnd_650x39_Cased_Mag_F_ca.paa";
+	displayName = "5.8 mm 10Rnd Tracer (Green) Mag";
+	displayNameShort = "";
+	tracersEvery=1;
+	lastRoundsTracer=10;
+  };
+};

--- a/QBU-88/config.cpp
+++ b/QBU-88/config.cpp
@@ -1,0 +1,120 @@
+class CfgPatches 
+{
+    class RSF_QBU88_Conversion 
+    {
+        name = "RSF QBU-88 Conversion Mod";
+        author = "Nero";
+        url = "";
+        version="0.0.1";
+        versionStr="0.0.1";
+        requiredAddons[] = {"A3_Weapons_F","ace_advanced_ballistics","ace_advanced_fatigue","ace_advanced_throwing",
+		"ace_ai","ace_aircraft","ace_apl","ace_arsenal","ace_atragmx","ace_attach","ace_backpacks","ace_ballistics",
+		"ace_captives","ace_cargo","ace_chemlights","ace_common","ace_concertina_wire","ace_cookoff","ace_dagr",
+		"ace_disarming","ace_disposable","ace_dogtags","ace_dragging","ace_explosives","ace_fastroping","ace_fcs",
+		"ace_finger","ace_flashlights","ace_flashsuppressors","ace_fonts","ace_frag","ace_gestures","ace_gforces",
+		"ace_goggles","ace_grenades","ace_gunbag","ace_hearing","ace_hellfire","ace_hitreactions","ace_hot",
+		"ace_huntir","ace_interact_menu","ace_interaction","ace_inventory","ace_javelin","ace_kestrel4500",
+		"ace_laser","ace_laserpointer","ace_logistics_uavbattery","ace_logistics_wirecutter","ace_magazinerepack",
+		"ace_main","ace_map","ace_map_gestures","ace_maptools","ace_markers","ace_maverick","ace_medical","ace_medical_ai",
+		"ace_medical_blood","ace_medical_menu","ace_microdagr","ace_minedetector","ace_missileguidance","ace_missionmodules",
+		"ace_mk6mortar","ace_modules","ace_movement","ace_mx2a","ace_nametags","ace_nightvision","ace_nlaw","ace_noidle",
+		"ace_noradio","ace_norearm","ace_optics","ace_optionsmenu","ace_overheating","ace_overpressure","ace_parachute",
+		"ace_pylons","ace_quickmount","ace_rangecard","ace_realisticnames","ace_realisticweights","ace_rearm",
+		"ace_recoil","ace_refuel","ace_reload","ace_reloadlaunchers","ace_repair","ace_respawn","ace_safemode",
+		"ace_sandbag","ace_scopes","ace_slideshow","ace_smallarms","ace_spectator","ace_spottingscope","ace_switchunits",
+		"ace_tacticalladder","ace_tagging","ace_thermals","ace_trenches","ace_tripod","ace_ui","ace_vector",
+		"ace_vehiclelock","ace_vehicles","ace_viewdistance","ace_weaponselect","ace_weather","ace_winddeflection",
+		"ace_yardage450","ace_zeus"
+		};
+        units[] = {};
+        weapons[] = {};
+    };
+};
+
+class WeaponSlotsInfo;
+class MuzzleSlot;
+class SlotInfo;
+class CowsSlot;
+class CfgWeapons 
+{
+	
+class DMR_07_base_F;
+	
+	class srifle_DMR_07_blk_F: DMR_07_base_F
+    {
+        displayName="QBU-88 (Black)";
+		descriptionShort = "Marksman Rifle<br />Caliber: 5.8x42 mm";
+		magazines[] = 
+		{
+		"10Rnd_580x42_Mag_F",
+		"10Rnd_580x42_Mag_Tracer_F",
+		};
+        magazineWell[] = {""};
+		
+		class WeaponSlotsInfo: WeaponSlotsInfo
+		{
+			class MuzzleSlot: MuzzleSlot
+			{
+				linkProxy="\A3\data_f\proxies\weapon_slots\MUZZLE";
+				compatibleItems[]= 
+				{
+				"muzzle_snds_58_blk_f",
+				"muzzle_snds_58_hex_f",
+				"muzzle_snds_58_ghex_f"
+				};
+			};
+		};		
+    };
+	
+	class srifle_DMR_07_hex_F: DMR_07_base_F
+    {
+        displayName="QBU-88 (Hex)";
+		descriptionShort = "Marksman Rifle<br />Caliber: 5.8x42 mm";
+		magazines[] = 
+		{
+		"10Rnd_580x42_Mag_F",
+		"10Rnd_580x42_Mag_Tracer_F",
+		};
+        magazineWell[] = {""};
+		
+		class WeaponSlotsInfo: WeaponSlotsInfo
+		{
+			class MuzzleSlot: MuzzleSlot
+			{
+				linkProxy="\A3\data_f\proxies\weapon_slots\MUZZLE";
+				compatibleItems[]= 
+				{
+				"muzzle_snds_58_blk_f",
+				"muzzle_snds_58_hex_f",
+				"muzzle_snds_58_ghex_f"
+				};
+			};
+		};		
+    };
+	
+		class srifle_DMR_07_ghex_F: DMR_07_base_F
+    {
+        displayName="QBU-88 (Green Hex)";
+		descriptionShort = "Marksman Rifle<br />Caliber: 5.8x42 mm";
+		magazines[] = 
+		{
+		"10Rnd_580x42_Mag_F",
+		"10Rnd_580x42_Mag_Tracer_F",
+		};
+        magazineWell[] = {""};
+		
+		class WeaponSlotsInfo: WeaponSlotsInfo
+		{
+			class MuzzleSlot: MuzzleSlot
+			{
+				linkProxy="\A3\data_f\proxies\weapon_slots\MUZZLE";
+				compatibleItems[]= 
+				{
+				"muzzle_snds_58_blk_f",
+				"muzzle_snds_58_hex_f",
+				"muzzle_snds_58_ghex_f"
+				};
+			};
+		};		
+    };
+};

--- a/RFB/config.cpp
+++ b/RFB/config.cpp
@@ -1,0 +1,257 @@
+class cfgPatches 
+{
+    class RSF_RFB_Conversion 
+    {
+        name = "RSF RFB Conversion Mod";
+        author = "Nero";
+        url = "";
+        version="0.0.1";
+        versionStr="0.0.1";
+        requiredAddons[] = {"A3_Weapons_F","ace_advanced_ballistics","ace_advanced_fatigue","ace_advanced_throwing",
+		"ace_ai","ace_aircraft","ace_apl","ace_arsenal","ace_atragmx","ace_attach","ace_backpacks","ace_ballistics",
+		"ace_captives","ace_cargo","ace_chemlights","ace_common","ace_concertina_wire","ace_cookoff","ace_dagr",
+		"ace_disarming","ace_disposable","ace_dogtags","ace_dragging","ace_explosives","ace_fastroping","ace_fcs",
+		"ace_finger","ace_flashlights","ace_flashsuppressors","ace_fonts","ace_frag","ace_gestures","ace_gforces",
+		"ace_goggles","ace_grenades","ace_gunbag","ace_hearing","ace_hellfire","ace_hitreactions","ace_hot",
+		"ace_huntir","ace_interact_menu","ace_interaction","ace_inventory","ace_javelin","ace_kestrel4500",
+		"ace_laser","ace_laserpointer","ace_logistics_uavbattery","ace_logistics_wirecutter","ace_magazinerepack",
+		"ace_main","ace_map","ace_map_gestures","ace_maptools","ace_markers","ace_maverick","ace_medical","ace_medical_ai",
+		"ace_medical_blood","ace_medical_menu","ace_microdagr","ace_minedetector","ace_missileguidance","ace_missionmodules",
+		"ace_mk6mortar","ace_modules","ace_movement","ace_mx2a","ace_nametags","ace_nightvision","ace_nlaw","ace_noidle",
+		"ace_noradio","ace_norearm","ace_optics","ace_optionsmenu","ace_overheating","ace_overpressure","ace_parachute",
+		"ace_pylons","ace_quickmount","ace_rangecard","ace_realisticnames","ace_realisticweights","ace_rearm",
+		"ace_recoil","ace_refuel","ace_reload","ace_reloadlaunchers","ace_repair","ace_respawn","ace_safemode",
+		"ace_sandbag","ace_scopes","ace_slideshow","ace_smallarms","ace_spectator","ace_spottingscope","ace_switchunits",
+		"ace_tacticalladder","ace_tagging","ace_thermals","ace_trenches","ace_tripod","ace_ui","ace_vector",
+		"ace_vehiclelock","ace_vehicles","ace_viewdistance","ace_weaponselect","ace_weather","ace_winddeflection",
+		"ace_yardage450","ace_zeus"
+		};
+        units[] = {};
+        weapons[] = {};
+    };
+};
+
+class WeaponSlotsInfo;
+class MuzzleSlot;
+class SlotInfo;
+class CowsSlot;
+class PointerSlot;
+class Mode_SemiAuto;
+
+class CfgWeapons 
+{
+	
+class SDAR_base_F;	
+
+	 class arifle_SDAR_F: SDAR_base_F
+    {
+        displayName="RFB";
+		descriptionShort = "Assault Rifle Gun<br />Caliber: 7.62x51 mm";
+		magazines[] = 
+		{
+		"ACE_20Rnd_762x51_Mag_Tracer",
+		"ACE_20Rnd_762x51_Mag_Tracer_Dim",
+		"ACE_20Rnd_762x51_Mag_SD",
+		"ACE_10Rnd_762x51_M118LR_Mag",
+		"ACE_10Rnd_762x51_Mk316_Mod_0_Mag",
+		"ACE_10Rnd_762x51_Mk319_Mod_0_Mag",
+		"ACE_10Rnd_762x51_M993_AP_Mag",
+		"ACE_20Rnd_762x51_M118LR_Mag",
+		"ACE_20Rnd_762x51_Mk316_Mod_0_Mag",
+		"ACE_20Rnd_762x51_Mk319_Mod_0_Mag",
+		"ACE_20Rnd_762x51_M993_AP_Mag",
+		"20Rnd_762x51_Mag",
+		"10Rnd_Mk14_762x51_Mag",
+		"rhsusf_10Rnd_762x51_m118_special_Mag",
+		"rhsusf_10Rnd_762x51_m62_Mag",
+		"rhsusf_10Rnd_762x51_m993_Mag",
+		"rhsusf_20Rnd_762x51_m118_special_Mag",
+		"rhsusf_20Rnd_762x51_m62_Mag",
+		"rhsusf_20Rnd_762x51_m993_Mag",
+		"rhsusf_20Rnd_762x51_SR25_m118_special_Mag",
+		"rhsusf_20Rnd_762x51_SR25_m62_Mag",
+		"rhsusf_20Rnd_762x51_SR25_m993_Mag",
+		"UK3CB_BAF_762_20Rnd",
+		"UK3CB_BAF_762_20Rnd_Blank",
+		"UK3CB_BAF_762_20Rnd_T"
+		};
+        magazineWell[] = {"CBA_762x51_G3","M14_762x51"};
+		modes[]=
+		{
+			"Single",
+		};	
+		
+		class WeaponSlotsInfo: WeaponSlotsInfo
+		{	
+				
+			class CowsSlot
+			{
+				linkProxy="\A3\data_f\proxies\weapon_slots\TOP";
+				compatibleItems[] = 
+				{
+				"rhsusf_acc_LEUPOLDMK4",
+				"rhsusf_acc_LEUPOLDMK4_d",
+				"rhsusf_acc_LEUPOLDMK4_wd",
+				"rhsusf_acc_LEUPOLDMK4_2",
+				"rhsusf_acc_LEUPOLDMK4_2_d",
+				"rhsusf_acc_premier",
+				"rhsusf_acc_premier_low",
+				"rhsusf_acc_premier_anpvs27",
+				"rhsusf_acc_ACOG_anpvs27",
+				"rhsusf_acc_M8541",
+				"rhsusf_acc_M8541_low",
+				"rhsusf_acc_M8541_low_d",
+				"rhsusf_acc_M8541_low_wd",
+				"rhsusf_acc_SpecterDR_pvs27",
+				"rhsusf_acc_EOTECH",
+				"rhsusf_acc_eotech_552",
+				"rhsusf_acc_eotech_552_d",
+				"rhsusf_acc_eotech_552_wd",
+				"rhsusf_acc_eotech_xps3",
+				"rhsusf_acc_g33_xps3",
+				"rhsusf_acc_g33_xps3_flip",
+				"rhsusf_acc_g33_xps3_tan",
+				"rhsusf_acc_g33_xps3_tan_flip",
+				"rhsusf_acc_g33_t1",
+				"rhsusf_acc_g33_t1_flip",
+				"rhsusf_acc_compm4",
+				"rhsusf_acc_T1_high",
+				"rhsusf_acc_T1_low",
+				"rhsusf_acc_RX01",
+				"rhsusf_acc_RX01_NoFilter",
+				"rhsusf_acc_RX01_tan",
+				"rhsusf_acc_RX01_NoFilter_tan",
+				"rhsusf_acc_RM05",
+				"rhsusf_acc_mrds",
+				"rhsusf_acc_mrds_c",
+				"rhsusf_acc_ACOG",
+				"rhsusf_acc_ACOG2",
+				"rhsusf_acc_ACOG3",
+				"rhsusf_acc_ACOG_wd",
+				"rhsusf_acc_ACOG_d",
+				"rhsusf_acc_ACOG_sa",
+				"rhsusf_acc_ACOG_USMC",
+				"rhsusf_acc_ACOG2_USMC",
+				"rhsusf_acc_ACOG3_USMC",
+				"rhsusf_acc_ACOG_RMR",
+				"rhsusf_acc_ACOG_PIP",
+				"rhsusf_acc_ACOG2_pip",
+				"rhsusf_acc_ACOG3_pip",
+				"rhsusf_acc_ACOG_wd_pip",
+				"rhsusf_acc_ACOG_d_pip",
+				"rhsusf_acc_ACOG_sa_pip",
+				"rhsusf_acc_ACOG_USMC_pip",
+				"rhsusf_acc_ACOG2_USMC_pip",
+				"rhsusf_acc_ACOG3_USMC_pip",
+				"rhsusf_acc_ACOG_RMR_PIP",
+				"rhsusf_acc_ACOG_3d",
+				"rhsusf_acc_ACOG2_3d",
+				"rhsusf_acc_ACOG3_3d",
+				"rhsusf_acc_ACOG_wd_3d",
+				"rhsusf_acc_ACOG_d_3d",
+				"rhsusf_acc_ACOG_sa_3d",
+				"rhsusf_acc_ACOG_USMC_3d",
+				"rhsusf_acc_ACOG2_USMC_3d",
+				"rhsusf_acc_ACOG3_USMC_3d",
+				"rhsusf_acc_ACOG_RMR_3d",
+				"rhsusf_acc_ELCAN",
+				"rhsusf_acc_ELCAN_ard",
+				"rhsusf_acc_ELCAN_3d",
+				"rhsusf_acc_ELCAN_ard_3d",
+				"rhsusf_acc_ELCAN_PIP",
+				"rhsusf_acc_ELCAN_ard_PIP",
+				"rhsusf_acc_su230",
+				"rhsusf_acc_su230_mrds",
+				"rhsusf_acc_su230a",
+				"rhsusf_acc_su230a_mrds",
+				"rhsusf_acc_su230_c",
+				"rhsusf_acc_su230_mrds_c",
+				"rhsusf_acc_su230a_c",
+				"rhsusf_acc_su230a_mrds_c",
+				"rhsusf_acc_su230_3d",
+				"rhsusf_acc_su230_mrds_3d",
+				"rhsusf_acc_su230a_3d",
+				"rhsusf_acc_su230a_mrds_3d",
+				"rhsusf_acc_su230_c_3d",
+				"rhsusf_acc_su230_mrds_c_3d",
+				"rhsusf_acc_su230a_c_3d",
+				"rhsusf_acc_su230a_mrds_c_3d",
+				"rhsusf_acc_SpecterDR",
+				"rhsusf_acc_SpecterDR_3d",
+				"rhsusf_acc_SpecterDR_A",
+				"rhsusf_acc_SpecterDR_A_3d",
+				"rhsusf_acc_SpecterDR_CX",
+				"rhsusf_acc_SpecterDR_CX_3D",
+				"rhsusf_acc_SpecterDR_D",
+				"rhsusf_acc_SpecterDR_OD",
+				"rhsusf_acc_SpecterDR_D_3D",
+				"rhsusf_acc_SpecterDR_OD_3D",
+				"rhsusf_acc_anpvs27",
+				"rhsusf_acc_anpas13gv1",
+				"rhsusf_acc_M2A1",
+				"rhsusf_acc_ACOG_MDO",
+				"optic_ico_01_f",
+				"optic_ico_01_black_f",
+				"optic_ico_01_sand_f",
+				"optic_ico_01_camo_f",
+				"optic_Nightstalker",
+				"optic_tws",
+				"optic_tws_mg",
+				"optic_NVS",
+				"optic_DMS",
+				"optic_LRPS",
+				"optic_ams",
+				"optic_AMS_snd",
+				"optic_AMS_khk",
+				"optic_KHS_blk",
+				"optic_KHS_tan",
+				"optic_KHS_hex",
+				"optic_KHS_old",
+				"optic_SOS",
+				"optic_MRCO",
+				"optic_Arco",
+				"optic_aco",
+				"optic_ACO_grn",
+				"optic_aco_smg",
+				"optic_ACO_grn_smg",
+				"optic_hamr",
+				"optic_Holosight",
+				"optic_Holosight_smg",
+				"optic_Hamr_khk_F",
+				"optic_SOS_khk_F",
+				"optic_Arco_ghex_F",
+				"optic_Arco_blk_F",
+				"optic_DMS_ghex_F",
+				"optic_ERCO_blk_F",
+				"optic_ERCO_khk_F",
+				"optic_ERCO_snd_F",
+				"optic_LRPS_ghex_F",
+				"optic_LRPS_tna_F",
+				"optic_Holosight_blk_F",
+				"optic_Holosight_khk_F",
+				"optic_Holosight_smg_blk_F",
+				"optic_Holosight_smg_khk_F",
+				"optic_DMS_weathered_F",
+				"optic_DMS_weathered_Kir_F",
+				"optic_Arco_lush_F",
+				"optic_Arco_arid_F",
+				"optic_Arco_AK_blk_F",
+				"optic_Arco_AK_lush_F",
+				"optic_Arco_AK_arid_F",
+				"optic_Holosight_lush_F",
+				"optic_Holosight_arid_F",
+				"ACE_optic_Hamr_2D",
+				"ACE_optic_Hamr_PIP",
+				"ACE_optic_Arco_2D",
+				"ACE_optic_Arco_PIP",
+				"ACE_optic_MRCO_2D",
+				"ACE_optic_MRCO_PIP",
+				"ACE_optic_SOS_2D",
+				"ACE_optic_SOS_PIP",
+				"ACE_optic_LRPS_2D",
+				"ACE_optic_LRPS_PIP"
+				};
+			};
+		};	
+    };
+};	

--- a/Stoner 99/config.cpp
+++ b/Stoner 99/config.cpp
@@ -1,0 +1,113 @@
+class cfgPatches 
+{
+    class RSF_Stoner_99_Conversion 
+    {
+        name = "RSF Stoner 99 Conversion Mod";
+        author ="Nero";
+        url = "";
+        version="0.0.1";
+        versionStr="0.0.1";
+        requiredAddons[] = {"A3_Weapons_F","ace_advanced_ballistics","ace_advanced_fatigue","ace_advanced_throwing",
+		"ace_ai","ace_aircraft","ace_apl","ace_arsenal","ace_atragmx","ace_attach","ace_backpacks","ace_ballistics",
+		"ace_captives","ace_cargo","ace_chemlights","ace_common","ace_concertina_wire","ace_cookoff","ace_dagr",
+		"ace_disarming","ace_disposable","ace_dogtags","ace_dragging","ace_explosives","ace_fastroping","ace_fcs",
+		"ace_finger","ace_flashlights","ace_flashsuppressors","ace_fonts","ace_frag","ace_gestures","ace_gforces",
+		"ace_goggles","ace_grenades","ace_gunbag","ace_hearing","ace_hellfire","ace_hitreactions","ace_hot",
+		"ace_huntir","ace_interact_menu","ace_interaction","ace_inventory","ace_javelin","ace_kestrel4500",
+		"ace_laser","ace_laserpointer","ace_logistics_uavbattery","ace_logistics_wirecutter","ace_magazinerepack",
+		"ace_main","ace_map","ace_map_gestures","ace_maptools","ace_markers","ace_maverick","ace_medical","ace_medical_ai",
+		"ace_medical_blood","ace_medical_menu","ace_microdagr","ace_minedetector","ace_missileguidance","ace_missionmodules",
+		"ace_mk6mortar","ace_modules","ace_movement","ace_mx2a","ace_nametags","ace_nightvision","ace_nlaw","ace_noidle",
+		"ace_noradio","ace_norearm","ace_optics","ace_optionsmenu","ace_overheating","ace_overpressure","ace_parachute",
+		"ace_pylons","ace_quickmount","ace_rangecard","ace_realisticnames","ace_realisticweights","ace_rearm",
+		"ace_recoil","ace_refuel","ace_reload","ace_reloadlaunchers","ace_repair","ace_respawn","ace_safemode",
+		"ace_sandbag","ace_scopes","ace_slideshow","ace_smallarms","ace_spectator","ace_spottingscope","ace_switchunits",
+		"ace_tacticalladder","ace_tagging","ace_thermals","ace_trenches","ace_tripod","ace_ui","ace_vector",
+		"ace_vehiclelock","ace_vehicles","ace_viewdistance","ace_weaponselect","ace_weather","ace_winddeflection",
+		"ace_yardage450","ace_zeus"
+		};
+        units[] = {};
+        weapons[] = {};
+    };
+};
+
+class WeaponSlotsInfo;
+class MuzzleSlot;
+class SlotInfo;
+class CowsSlot;
+class PointerSlot;
+
+class CfgWeapons 
+{
+	class Rifle_Long_Base_F;
+	
+	class LMG_Mk200_F: Rifle_Long_Base_F
+    {
+        displayName="Stoner 99";
+		descriptionShort = "Light Machine Gun<br />Caliber: 5.56x45 mm";
+		linkProxy="\A3\data_f\proxies\weapon_slots\MAGAZINESLOT";
+		magazines[] = 
+		{
+		""
+		};
+        magazineWell[] = {"M249_556x45"};
+		
+	
+		class WeaponSlotsInfo: WeaponSlotsInfo
+		{
+			class MuzzleSlot: MuzzleSlot
+			{
+				linkProxy="\A3\data_f\proxies\weapon_slots\MUZZLE";
+				compatibleItems[]= 
+				{
+				"ace_muzzle_mzls_l",
+				"ffaa_snds_gt_556",
+				"rhsusf_acc_nt4_black",
+				"rhsusf_acc_nt4_tan",
+				"rhsusf_acc_rotex5_grey",
+				"rhsusf_acc_rotex5_tan",
+				"muzzle_snds_m_snd_f",
+				"muzzle_snds_m_khk_f",
+				"muzzle_snds_m"
+				
+				};
+			};
+		};		
+	
+    };
+	
+    class LMG_Mk200_black_F: LMG_Mk200_F
+    {
+        displayName="Stoner 99 (Black)";
+		descriptionShort = "Light Machine Gun<br />Caliber: 5.56x45 mm";
+		linkProxy="\A3\data_f\proxies\weapon_slots\MAGAZINESLOT";
+		magazines[] = 
+		{
+		""
+		};
+        magazineWell[] = {"M249_556x45"};
+		
+	
+		class WeaponSlotsInfo: WeaponSlotsInfo
+		{
+			class MuzzleSlot: MuzzleSlot
+			{
+				linkProxy="\A3\data_f\proxies\weapon_slots\MUZZLE";
+				compatibleItems[]= 
+				{
+				"ace_muzzle_mzls_l",
+				"ffaa_snds_gt_556",
+				"rhsusf_acc_nt4_black",
+				"rhsusf_acc_nt4_tan",
+				"rhsusf_acc_rotex5_grey",
+				"rhsusf_acc_rotex5_tan",
+				"muzzle_snds_m_snd_f",
+				"muzzle_snds_m_khk_f",
+				"muzzle_snds_m"
+				
+				};
+			};
+		};		
+	
+    };
+};


### PR DESCRIPTION
I think it would be good to keep the 'MSBS' designation on the custom MSBS mags to distinguish them from the STANAG mags, since we now have basically all types of normal STANAG ammo in the MSBS mags. 